### PR TITLE
tilesets and looks_like: don't over looks_like with copy-from

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1560,111 +1560,7 @@ bool cata_tiles::draw_from_id_string( std::string id, tripoint pos, int subtile,
                                             ll, apply_night_vision_goggles, height_3d );
 }
 
-const tile_type *cata_tiles::find_furniture_looks_like( std::string id, std::string &effective_id )
-{
-    std::string looks_like = id;
-    int cnt = 0;
-    while( !looks_like.empty() && cnt < 10 ) {
-        const tile_type *lltt = find_tile_with_season( looks_like );
-        if( lltt ) {
-            effective_id = looks_like;
-            return lltt;
-        }
-        const furn_str_id fid( looks_like );
-        if( !fid.is_valid() ) {
-            return nullptr;
-        }
-        const furn_t &furn = fid.obj();
-        looks_like = furn.looks_like;
-        cnt += 1;
-    }
-    return nullptr;
-}
-
-const tile_type *cata_tiles::find_terrain_looks_like( std::string id, std::string &effective_id )
-{
-    std::string looks_like = id;
-    int cnt = 0;
-    while( !looks_like.empty() && cnt < 10 ) {
-        const tile_type *lltt = find_tile_with_season( looks_like );
-        if( lltt ) {
-            effective_id = looks_like;
-            return lltt;
-        }
-        const ter_str_id tid( looks_like );
-        if( !tid.is_valid() ) {
-            return nullptr;
-        }
-        const ter_t &ter = tid.obj();
-        looks_like = ter.looks_like;
-        cnt += 1;
-    }
-    return nullptr;
-}
-
-const tile_type *cata_tiles::find_monster_looks_like( std::string id, std::string &effective_id )
-{
-    std::string looks_like = id;
-    int cnt = 0;
-    while( !looks_like.empty() && cnt < 10 ) {
-        const tile_type *lltt = find_tile_with_season( looks_like );
-        if( lltt ) {
-            effective_id = looks_like;
-            return lltt;
-        }
-        const mtype_id mid( looks_like );
-        if( !mid.is_valid() ) {
-            return nullptr;
-        }
-        const mtype &mt = mid.obj();
-        looks_like = mt.looks_like;
-        cnt += 1;
-    }
-    return nullptr;
-}
-
-const tile_type *cata_tiles::find_vpart_looks_like( std::string id, std::string &effective_id )
-{
-    std::string looks_like = id;
-    int cnt = 0;
-    while( !looks_like.empty() && cnt < 10 ) {
-        const tile_type *lltt = find_tile_with_season( "vp_" + looks_like );
-        if( lltt ) {
-            effective_id = "vp_" + looks_like;
-            return lltt;
-        }
-        const vpart_id new_vpid( looks_like );
-        if( !new_vpid.is_valid() ) {
-            return nullptr;
-        }
-        const vpart_info &new_vpi = new_vpid.obj();
-        looks_like = new_vpi.looks_like;
-        cnt += 1;
-    }
-    return nullptr;
-}
-
-const tile_type *cata_tiles::find_item_looks_like( std::string id, std::string &effective_id )
-{
-    std::string looks_like = id;
-    int cnt = 0;
-    while( !looks_like.empty() && cnt < 10 ) {
-        const tile_type *lltt = find_tile_with_season( looks_like );
-        if( lltt ) {
-            effective_id = looks_like;
-            return lltt;
-        }
-        if( !item::type_is_defined( looks_like ) ) {
-            return nullptr;
-        }
-        const itype *new_it = item::find_type( looks_like );
-        looks_like = new_it->looks_like;
-        cnt += 1;
-    }
-    return nullptr;
-}
-
-const tile_type *cata_tiles::find_tile_with_season( std::string id )
+const tile_type *cata_tiles::find_tile_with_season( std::string &id )
 {
     constexpr size_t suffix_len = 15;
     constexpr char season_suffix[4][suffix_len] = {
@@ -1675,12 +1571,66 @@ const tile_type *cata_tiles::find_tile_with_season( std::string id )
 
     const tile_type *tt = tileset_ptr->find_tile_type( seasonal_id );
     if( tt ) {
-        id = std::move( seasonal_id );
+        id = seasonal_id;
     } else {
         tt = tileset_ptr->find_tile_type( id );
     }
     return tt;
 }
+
+const tile_type *cata_tiles::find_tile_looks_like( std::string &id, TILE_CATEGORY category )
+{
+    std::string looks_like = id;
+    int cnt = 0;
+    while( !looks_like.empty() && cnt < 10 ) {
+        const tile_type *lltt = find_tile_with_season( looks_like );
+        if( lltt ) {
+            id = looks_like;
+            return lltt;
+        }
+        if( category == C_FURNITURE ) {
+            const furn_str_id fid( looks_like );
+            if( !fid.is_valid() ) {
+                return nullptr;
+            }
+            const furn_t &furn = fid.obj();
+            looks_like = furn.looks_like;
+        } else if( category == C_TERRAIN ) {
+            const ter_str_id tid( looks_like );
+            if( !tid.is_valid() ) {
+                return nullptr;
+            }
+            const ter_t &ter = tid.obj();
+            looks_like = ter.looks_like;
+        } else if( category == C_MONSTER ) {
+            const mtype_id mid( looks_like );
+            if( !mid.is_valid() ) {
+                return nullptr;
+            }
+            const mtype &mt = mid.obj();
+            looks_like = mt.looks_like;
+        } else if( category == C_VEHICLE_PART ) {
+            // vehicle parts start with vp_ for their tiles, but not their IDs
+            const vpart_id new_vpid( looks_like.substr( 3 ) );
+            if( !new_vpid.is_valid() ) {
+                return nullptr;
+            }
+            const vpart_info &new_vpi = new_vpid.obj();
+            looks_like = "vp_" + new_vpi.looks_like;
+        } else if( category == C_ITEM ) {
+            if( !item::type_is_defined( looks_like ) ) {
+                return nullptr;
+            }
+            const itype *new_it = item::find_type( looks_like );
+            looks_like = new_it->looks_like;
+        } else {
+            return nullptr;
+        }
+        cnt += 1;
+    }
+    return nullptr;
+}
+
 
 bool cata_tiles::draw_from_id_string( std::string id, TILE_CATEGORY category,
                                       const std::string &subcategory, tripoint pos,
@@ -1700,58 +1650,45 @@ bool cata_tiles::draw_from_id_string( std::string id, TILE_CATEGORY category,
         return false;
     }
 
-    std::string effective_id;
-    const tile_type *tt = find_tile_with_season( id );
+    const tile_type *tt = find_tile_looks_like( id, category );
 
     if( !tt ) {
         uint32_t sym = UNKNOWN_UNICODE;
         nc_color col = c_white;
         if( category == C_FURNITURE ) {
-            tt = find_furniture_looks_like( id, effective_id );
-            if( !tt ) {
-                const furn_str_id fid( id );
-                if( fid.is_valid() ) {
-                    const furn_t &f = fid.obj();
-                    sym = f.symbol();
-                    col = f.color();
-                }
+            const furn_str_id fid( id );
+            if( fid.is_valid() ) {
+                const furn_t &f = fid.obj();
+                sym = f.symbol();
+                col = f.color();
             }
         } else if( category == C_TERRAIN ) {
-            tt = find_terrain_looks_like( id, effective_id );
-            if( !tt ) {
-                const ter_str_id tid( id );
-                if( tid.is_valid() ) {
-                    const ter_t &t = tid.obj();
-                    sym = t.symbol();
-                    col = t.color();
-                }
+            const ter_str_id tid( id );
+            if( tid.is_valid() ) {
+                const ter_t &t = tid.obj();
+                sym = t.symbol();
+                col = t.color();
             }
         } else if( category == C_MONSTER ) {
-            tt = find_monster_looks_like( id, effective_id );
-            if( !tt ) {
-                const mtype_id mid( id );
-                if( mid.is_valid() ) {
-                    const mtype &mt = mid.obj();
-                    int len = mt.sym.length();
-                    const char *s = mt.sym.c_str();
-                    sym = UTF8_getch( &s, &len );
-                    col = mt.color;
-                }
+            const mtype_id mid( id );
+            if( mid.is_valid() ) {
+                const mtype &mt = mid.obj();
+                int len = mt.sym.length();
+                const char *s = mt.sym.c_str();
+                sym = UTF8_getch( &s, &len );
+                col = mt.color;
             }
         } else if( category == C_VEHICLE_PART ) {
-            tt = find_vpart_looks_like( id.substr( 3 ), effective_id );
-            if( !tt ) {
-                const vpart_id vpid( id.substr( 3 ) );
-                if( vpid.is_valid() ) {
-                    const vpart_info &v = vpid.obj();
-                    sym = v.sym;
-                    if( !subcategory.empty() ) {
-                        sym = special_symbol( subcategory[0] );
-                        rota = 0;
-                        subtile = -1;
-                    }
-                    col = v.color;
+            const vpart_id vpid( id.substr( 3 ) );
+            if( vpid.is_valid() ) {
+                const vpart_info &v = vpid.obj();
+                sym = v.sym;
+                if( !subcategory.empty() ) {
+                    sym = special_symbol( subcategory[0] );
+                    rota = 0;
+                    subtile = -1;
                 }
+                col = v.color;
             }
         } else if( category == C_FIELD ) {
             const field_id fid = field_from_ident( id );
@@ -1766,12 +1703,9 @@ bool cata_tiles::draw_from_id_string( std::string id, TILE_CATEGORY category,
                 col = t.color;
             }
         } else if( category == C_ITEM ) {
-            tt = find_item_looks_like( id, effective_id );
-            if( !tt ) {
-                const auto tmp = item( id, 0 );
-                sym = tmp.symbol().empty() ? ' ' : tmp.symbol().front();
-                col = tmp.color();
-            }
+            const auto tmp = item( id, 0 );
+            sym = tmp.symbol().empty() ? ' ' : tmp.symbol().front();
+            col = tmp.color();
         }
         // Special cases for walls
         switch(sym) {
@@ -1835,9 +1769,6 @@ bool cata_tiles::draw_from_id_string( std::string id, TILE_CATEGORY category,
         return false;
     }
 
-    if( effective_id.empty() ) {
-        effective_id = id;
-    }
     const tile_type &display_tile = *tt;
     // check to see if the display_tile is multitile, and if so if it has the key related to subtile
     if (subtile != -1 && display_tile.multitile) {
@@ -1846,7 +1777,7 @@ bool cata_tiles::draw_from_id_string( std::string id, TILE_CATEGORY category,
         if (std::find(begin(display_subtiles), end, multitile_keys[subtile]) != end) {
             // append subtile name to tile and re-find display_tile
             return draw_from_id_string(
-                std::move( effective_id.append( "_", 1 ).append( multitile_keys[subtile] ) ),
+                std::move( id.append( "_", 1 ).append( multitile_keys[subtile] ) ),
                 pos, -1, rota, ll, apply_night_vision_goggles, height_3d );
         }
     }

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -402,12 +402,8 @@ class cata_tiles
         /** How many rows and columns of tiles fit into given dimensions **/
         void get_window_tile_counts( const int width, const int height, int &columns, int &rows ) const;
 
-        const tile_type *find_furniture_looks_like( std::string id, std::string &effective_id );
-        const tile_type *find_terrain_looks_like( std::string id, std::string &effective_id );
-        const tile_type *find_monster_looks_like( std::string id, std::string &effective_id );
-        const tile_type *find_vpart_looks_like( std::string id, std::string &effective_id );
-        const tile_type *find_item_looks_like( std::string id, std::string &effective_id );
-        const tile_type *find_tile_with_season( std::string id );
+        const tile_type *find_tile_with_season( std::string &id );
+        const tile_type *find_tile_looks_like( std::string &id, TILE_CATEGORY category );
 
         bool draw_from_id_string( std::string id, tripoint pos, int subtile, int rota, lit_level ll,
                                   bool apply_night_vision_goggles );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1185,7 +1185,9 @@ bool Item_factory::load_definition( JsonObject &jo, const std::string &src, ityp
     auto abstract = m_abstracts.find( jo.get_string( "copy-from" ) );
     if( abstract != m_abstracts.end() ) {
         def = abstract->second;
-        def.looks_like = jo.get_string( "copy-from" );
+        if( def.looks_like.empty() ) {
+            def.looks_like = jo.get_string( "copy-from" );
+        }
         return true;
     }
 

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -320,7 +320,7 @@ std::string map_data_common_t::name() const
 
 void map_data_common_t::load_symbol( JsonObject &jo )
 {
-    if( jo.has_member( "copy-from" ) ) {
+    if( jo.has_member( "copy-from" ) && looks_like.empty() ) {
         looks_like = jo.get_string( "copy-from" );
     }
     if( jo.has_member( "looks_like" ) ) {

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -532,7 +532,7 @@ void mtype::load( JsonObject &jo, const std::string &src )
             jo.throw_error( "monster symbol should be exactly one console cell width", "symbol" );
         }
     }
-    if( was_loaded && jo.has_member( "copy-from" ) ) {
+    if( was_loaded && jo.has_member( "copy-from" ) && looks_like.empty() ) {
         looks_like = jo.get_string( "copy-from" );
     }
     if( jo.has_member( "looks_like" ) ) {

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -158,7 +158,9 @@ void vpart_info::load( JsonObject &jo, const std::string &src )
             def.looks_like = base->second.id.str();
         } else if( ab != abstract_parts.end() ) {
             def = ab->second;
-            def.looks_like = ab->second.id.str();
+            if( def.looks_like.empty() ) {
+                def.looks_like = ab->second.id.str();
+            }
         } else {
             deferred.emplace_back( jo.str(), src );
             return;


### PR DESCRIPTION
when generating looks_like from a copy-from, don't overwrite an existing
looks_like that was in the underlying abstract item.