### PR TITLE
Tileset compositor script

### DIFF
--- a/doc/TILESET.md
+++ b/doc/TILESET.md
@@ -1,0 +1,229 @@
+# TILESETS
+A tileset provides graphic images for the game.  Each tileset has one or more tilesheets of image sprites and a `tile_config.json` file that describes how to map the contents of the sprite sheets to various entities in the game.  It also has a `tileset.txt` file that provides metadata.
+
+## Compositing Tilesets
+Prior October 2019, tilesets had to be submitted to the repo with each tilesheet fully composited and the sprite indices in `tile_config.json` calculated by hand.  After October 2019, tilesets can be submitted to repos as directories of individual sprite files and tile entry JSON files that used sprite file names, and a Python script that runs at compile time would merge the sprite images into tilesheets, convert the files names into sprite indices for the tile entries, and merge the tile entries into a `tile_config.json`.
+
+For the rest of this document, tilesets that are submitted as fully composited tilesheets are called legacy tilesets, and tilesets that submitted as individual sprite image files are compositing tilesets.
+
+### tools/gfx_tools/decompose.py
+This is a Python script that will convert a legacy tileset into a compositing tileset.  It reads the `tile_config.json` and assigns semi-arbitrary file names to each sprite index.  Then it changes all the sprite indexes references to the file names.  Then it breaks up `tile_config.json` into many small tile_entry JSON files with arbitrary file names, and pulls out each sprite and writes it to aseparate file.
+
+It requires pyvips to do the image processing.
+
+It takes a single mandatory argument, which is the path to the tileset directory.  For example:
+`python tools/gfx_tools/decompose.py gfx/ChestHole16Tileset` will convert the legacy ChestHole16 tileset to a compositing tileset.
+
+decompose.py creates a sufficient directory hierarchy and file names for a tileset to be compositing, but it is machine generated and badly organized.  New compositing tilesets should use more sensible file names and a better organization.
+
+It shouldn't be necessary to run decompose.py very often.  Legacy tilesets should only need to be converted to composite tilesets one time.
+
+### tools/gfx_tools/compose.py
+This is a Python script that creates the tilesheets for a compositing tileset.  It reads all of the directories in a tileset's directory with names that start with `pngs_` for sprite files and `tile_entry` JSON files, creates mappings of sprite file names to indices, merges the sprite files into tilesheets, changes all of the sprite file name references in the `tile_entries` to indices, and merges the `tile_entries` into a `tile_config.json`.
+
+Like decompose.py, it requires pyvips to the image processing.
+
+The original sprite files and `tile_entry` JSON files are preserved.
+
+### directory structure
+Each compositing tileset has one or more directories in it with a name that starts with `pngs_`, such as `pngs_tree_32x40` or `pngs_overlay`.  These are the image directories.  All of the sprites in an image directory must have the same height and width and will be merged into a single tilesheet.
+
+It is recommended that tileset developers include the sprite dimensions in the image directory name, but this is not required.  `pngs_overlay_24x24` is preferred over `pngs_overlay` but both are allowed.  As each image directory creates its own tilesheet, and tilesheets should be as large as possible for performance reasons, tileset developers are strongly encouraged to minimize the number of image directories.
+
+Each image directory contains a hierarchy of subdirectories, `tile_entry` JSON files, and sprite files.  There is no restriction on the arrangement or names of these files, except for `tile_entry` JSON files for expansion tilesheets must be at the top level of the image directory.  Subdirectories are not required but are recommended to keep things manageable.
+
+#### `tile_entry` JSON
+Each `tile_entry` JSON is a dictionary that describes how to map one or more game entities to one or more sprites.  The simplest version has a single game entity, a single foreground sprite, an *optional* background sprite, and a rotation value.  For instance:
+```C++
+{                                           // this is an object and doesn't require a list
+    "id": "mon_cat",                        // the game entity represented by this sprite
+    "fg": "mon_cat_black",                  // some sprite name
+    "bg": "shadow_bg_1",                    // some sprite name; always a single value
+    "rotates": false                        // true for things that rotate like vehicle parts
+}
+```
+
+The values in `"id"`, `"fg"`, and `"bg"` can be repeated within an image directory or in different image directories.  `"fg"` and `"bg"` sprite images can be referenced across image directories, but the sprites must be stored in an image directory with other sprites of the same height and width.
+
+`"id"` can also be a list of multiple game entities sharing the same sprite, like `"id": ["vp_door"], ["vp_hddoor"]`.  `"id"` can be any vehicle part, terrain, furniture, item, or monster in the game.  The special ids `"player_female", "player_male", "npc_female", "npc_male"` are used to identify the sprites for the player avatar and NPCs.  The special id `"unknown"` provides a sprite that is displayed when an entity has no other sprite.
+
+The special suffixes `_season_spring`, `_season_summer`, `_season_autumn`, and `_season_winter` can be applied to any entity id to create a seasonal variant for that entity that will be displayed in the appropriate season like this `"id": "mon_wolf_season_winter"`.
+
+The special prefixes `overlay_mutation_`, `overlay_female_mutation_`, `overlay_male_mutation_` can prefix any trait or bionic in the game to specify an overlay image that will be laid over the player and NPC sprites to indicate they have that mutation or bionic.
+
+The special prefixes `overlay_worn_`, `overlay_female_worn_`, `overlay_male_worn_` can prefix any item in the game to specify an overlay image that will be laid over the player and NPC sprites to indicate they are wearing that item.
+
+The special prefixes `overlay_wielded_`, `overlay_female_wielded_`, `overlay_male_wielded_` can prefix any item in the game to specify an overlay image that will be laid over the player and NPC sprites to indicate they are holding that item.
+
+`"fg"` and `"bg"` can also be a list of 2 or 4 pre-rotated rotational variants, like `"bg": ["t_wall_n", "t_wall_e", "t_wall_s", "t_wall_w"]` or `"fg": ["mon_dog_left", "mon_dog_right"]`.
+
+`"fg"` and `"bg"` can also be a list of dictionaries of weighted, randomly chosen options, any of which can also be a rotated list:
+```C++
+    "fg": [
+        { "weight": 50, "sprite": "t_dirt_brown"},       // appears in 50 of 53 tiles
+        { "weight": 1, "sprite": "t_dirt_black_specks"}, // appears 1 in 53 tiles
+        { "weight": 1, "sprite": "t_dirt_specks_gray"},
+        { "weight": 1, "sprite": "t_patchy_grass"}       // file names are arbitrary
+    ],
+```
+
+`"multitle"` is an *optional* field.  If it is present and `true`, there must be an `additional_tiles` list with 1 or more dictionaries for entities and sprites associated with this tile, such as broken versions of an item or wall connections.  Each dictionary in the list has an `"id`" field, as above, and a `"fg"` field, which can be a single filename, a list of filenames, or a list of dictionaries as above.
+
+#### expansion `tile_entry` JSON
+Tilesheets can have expansion tilesheets, which are tilesheets from mods.  Each expansion tilesheet is a single `"id"` value, `"rotates": false"`, and `"fg": 0`.  Expansion `tile_entry` JSON are the only `tile_entry` JSONs that use an integer value for `"fg"` and that value must be 0.  Expansion `tile_entry` JSONs must be located at the top layer of each image directory.
+
+#### Sprite Images
+Every sprite inside an image directory must have the same height and width as every other sprite in the image directory.
+
+Sprites can be organized into subdirectories within the image directory however the tileset developer prefers.  Sprite filenames are completely arbitrary and should be chosen using a scheme that makes sense to the tileset developer.
+
+After loading a tileset, config/debug.log will contain a space separated list of every entity missing a sprite in the tileset.  Entities that have sprites because of a `"looks_like"` definition will not show up in the list.
+
+### `tile_info.json`
+Each compositing tileset *must* have a `tile_info.json`, laid out like so:
+```
+[
+  {
+    "width": 32,
+    "pixelscale": 1,
+    "height": 32
+  },
+  {
+    "1_tiles_32x32_0-5199.png": {}
+  },
+  {
+    "2_expan_32x32_5200-5391.png": {}
+  },
+  {
+    "3_tree_64x80_5392-5471.png": {
+      "sprite_offset_x": -16,
+      "sprite_offset_y": -48,
+      "sprite_height": 80,
+      "sprite_width": 64
+    }
+  },
+  {
+    "4_fallback_5472-9567.png": { "fallback": true }
+  }
+]
+```
+The first dictionary is mandatory, and gives the default sprite width and sprite height for all tilesheets in the tileset.  Each of the image directories must have a separate dictionary, containing the tilesheet png name as its key.  If the tilesheet has the default sprite dimensions and no special offsets, it can have an empty dictionary as the value for the tilesheet name key.  Otherwise, it should have a dictionary of the sprite offsets, height, and width.
+
+A special key is `"fallback"` which should be `true` if present.  If a tilesheet is designated as fallback, it will be treated as a tilesheet of fallback ASCII characters.  `compose.py` will also compose the fallback tilesheet to the end of the tileset, and will add a "fallback.png" to `tile_config.json` if there is no `"fallback"` entry in `tile_info.json`.
+
+## Legacy tilesets
+### tilesheets
+Each tilesheet contains 1 or more sprites with the same width and height.  Each tilesheet contains one or more rows of exactly 16 sprites.  Sprite index 0 is special and the first sprite of the first tilesheet in a tileset should be blank.  Indices run sequentially through each sheet and continue incrementing for each new sheet without reseting, so index 32 is the first sprite in the third row of the first sheet.  If the first sheet has 320 sprites in it, index 352 would be the first sprite of the third row of the second sheet.
+
+### `tile_config`
+Each legacy tileset has a `tile_config.json` describing how to map the contents of a sprite sheet to various tile identifiers, different orientations, etc. The ordering of the overlays used for displaying mutations can be controlled as well. The ordering can be used to override the default ordering provided in `mutation_ordering.json`. Example:
+
+```C++
+  {                                             // whole file is a single object
+    "tile_info": [                              // tile_info is mandatory
+      {
+        "height": 32,
+        "width": 32,
+        "iso" : true,                             //  Optional. Indicates an isometric tileset. Defaults to false.
+        "pixelscale" : 2                          //  Optional. Sets a multiplier for resizing a tileset. Defaults to 1.
+      }
+    ],
+    "tiles-new": [                              // tiles-new is an array of sprite sheets
+      {                                           //   alternately, just one "tiles" array
+        "file": "tiles.png",                      // file containing sprites in a grid
+        "tiles": [                                // array with one entry per tile
+          {
+            "id": "10mm",                         // id is how the game maps things to sprites
+            "fg": 1,                              //   lack of prefix mostly indicates items
+            "bg": 632,                            // fg and bg can be sprite indexes in the image
+            "rotates": false
+          },
+          {
+            "id": "t_wall",                       // "t_" indicates terrain
+            "fg": [2918, 2919, 2918, 2919],       // 2 or 4 sprite numbers indicates pre-rotated
+            "bg": 633,
+            "rotates": true,
+            "multitile": true,
+            "additional_tiles": [                 // connected/combined versions of sprite
+              {                                   //   or variations, see below
+                "id": "center",
+                "fg": [2919, 2918, 2919, 2918]
+              },
+              {
+                "id": "corner",
+                "fg": [2924, 2922, 2922, 2923]
+              },
+              {
+                "id": "end_piece",
+                "fg": [2918, 2919, 2918, 2919]
+              },
+              {
+                "id": "t_connection",
+                "fg": [2919, 2918, 2919, 2918]
+              },
+              {
+                "id": "unconnected",
+                "fg": 2235
+              }
+            ]
+          },
+          {
+            "id": "vp_atomic_lamp",               // "vp_" vehicle part
+            "fg": 3019,
+            "bg": 632,
+            "rotates": false,
+            "multitile": true,
+            "additional_tiles": [
+              {
+                "id": "broken",                   // variant sprite
+                "fg": 3021
+              }
+            ]
+          },
+          {
+            "id": "t_dirt",
+            "rotates": false,
+            "fg": [
+              { "weight":50, "sprite":640},       // weighted random variants
+              { "weight":1, "sprite":3620},
+              { "weight":1, "sprite":3621},
+              { "weight":1, "sprite":3622}
+            ]
+          },
+          {
+            "id": [
+              "overlay_mutation_GOURMAND",        // character overlay for mutation
+              "overlay_mutation_male_GOURMAND",   // overlay for specified gender
+              "overlay_mutation_active_GOURMAND"  // overlay for activated mutation
+            ],
+            "fg": 4040
+          }
+        ]
+      },
+      {                                           // second entry in tiles-new
+        "file": "moretiles.png",                  // another sprite sheet
+        "tiles": [
+          {
+            "id": ["xxx","yyy"],                  // define two ids at once
+            "fg": 1,
+            "bg": 234
+          }
+        ]
+      }d
+    ],
+    "overlay_ordering": [
+      {
+        "id" : "WINGS_BAT",                         // mutation name, in a string or array of strings
+        "order" : 1000                              // range from 0 - 9999, 9999 being the topmost layer
+      },
+      {
+        "id" : [ "PLANTSKIN", "BARK" ],             // mutation name, in a string or array of strings
+        "order" : 3500                              // order is applied to all items in the array
+      },
+      {
+        "id" : "bio_armor_torso",                   // Overlay order of bionics is controlled in the same way
+        "order" : 500
+      }
+    ]
+  }
+```

--- a/tools/gfx_tools/compose.py
+++ b/tools/gfx_tools/compose.py
@@ -1,0 +1,284 @@
+#!/bin/python
+
+# compose.py
+# Split a gfx directory made of 1000s of little images and files into a set of tilesheets
+# and a tile_config.json
+
+import argparse
+import copy
+import json
+import os
+import string
+import subprocess
+
+try:
+    import pyvips
+    Vips = pyvips
+except ImportError:
+    import gi
+    gi.require_version('Vips', '8.0')
+    from gi.repository import Vips
+
+FALLBACK = {
+    "file": "fallback.png",
+    "tiles": [],
+    "ascii": [
+        { "offset": 0, "bold": False, "color": "BLACK" },
+        { "offset": 256, "bold": True, "color": "WHITE" },
+        { "offset": 512, "bold": False, "color": "WHITE" },
+        { "offset": 768, "bold": True, "color": "BLACK" },
+        { "offset": 1024, "bold": False, "color": "RED" },
+        { "offset": 1280, "bold": False, "color": "GREEN" },
+        { "offset": 1536, "bold": False, "color": "BLUE" },
+        { "offset": 1792, "bold": False, "color": "CYAN" },
+        { "offset": 2048, "bold": False, "color": "MAGENTA" },
+        { "offset": 2304, "bold": False, "color": "YELLOW" },
+        { "offset": 2560, "bold": True, "color": "RED" },
+        { "offset": 2816, "bold": True, "color": "GREEN" },
+        { "offset": 3072, "bold": True, "color": "BLUE" },
+        { "offset": 3328, "bold": True, "color": "CYAN" },
+        { "offset": 3584, "bold": True, "color": "MAGENTA" },
+        { "offset": 3840, "bold": True, "color": "YELLOW" }
+    ]
+}
+
+# stupid stinking Python 2 versus Python 3 syntax
+def write_to_json(pathname, data):
+    with open(pathname, "w") as fp:
+        try:
+            json.dump(data, fp)
+        except ValueError:
+            fp.write(json.dumps(data))
+    cmd = ["./tools/format/json_formatter.cgi", pathname]
+    subprocess.call(cmd)
+
+
+def find_or_make_dir(pathname):
+    try:
+        os.stat(pathname)
+    except OSError:
+        os.mkdir(pathname)
+
+
+class PngRefs(object):
+    def __init__(self, tileset_dirname):
+        # dict of pngnames to png numbers; used to control uniqueness
+        self.pngname_to_pngnum = { "null_image": 0 }
+        # dict of png absolute numbers to png names
+        self.pngnum_to_pngname = { 0: "null_image" }
+        self.pngnum = 0
+        self.tileset_pathname = tileset_dirname
+        if not tileset_dirname.startswith("gfx/"):
+            self.tileset_pathname = "gfx/" + tileset_dirname
+
+        try:
+            os.stat(self.tileset_pathname)
+        except KeyError:
+            print("cannot find a directory {}".format(self.tileset_pathname))
+            exit -1
+
+        tileset_info_path = self.tileset_pathname + "/tile_info.json"
+        self.tileset_width = 16
+        self.tileset_height = 16
+        self.tileset_info = [{}]
+        with open(tileset_info_path, "r") as fp:
+            self.tileset_info = json.load(fp)
+            self.tileset_width = self.tileset_info[0].get("width")
+            self.tileset_height = self.tileset_info[0].get("height")
+
+    def convert_pngname_to_pngnum(self, index):
+        new_index = []
+        if isinstance(index, list):
+            for pngname in index:
+                if isinstance(pngname, dict):
+                    sprite_ids = pngname.get("sprite")
+                    valid = False
+                    if isinstance(sprite_ids, list):
+                        new_sprites = []
+                        for sprite_id in sprite_ids:
+                            if sprite_id != "no_entry":
+                                new_sprites.append(self.pngname_to_pngnum.get(sprite_id, 0))
+                                valid = True
+                        pngname["sprite"] = new_sprites
+                    elif sprite_ids and sprite_ids != "no_entry":
+                        pngname["sprite"] = self.pngname_to_pngnum.get(sprite_ids, 0)
+                        valid = True
+                    if valid:
+                        new_index.append(pngname)
+                elif pngname != "no_entry":
+                    new_index.append(self.pngname_to_pngnum.get(pngname, 0))
+        elif index and index != "no_entry":
+            new_index.append(self.pngname_to_pngnum.get(index, 0))
+        if new_index and len(new_index) == 1:
+            return new_index[0]
+        return new_index
+
+    def convert_tile_entry(self, tile_entry):
+        fg_id = tile_entry.get("fg")
+        if fg_id:
+            tile_entry["fg"] = self.convert_pngname_to_pngnum(fg_id)
+
+        bg_id = tile_entry.get("bg")
+        if bg_id:
+            tile_entry["bg"] = self.convert_pngname_to_pngnum(bg_id)
+
+        add_tile_entrys = tile_entry.get("additional_tiles", [])
+        for add_tile_entry in add_tile_entrys:
+            self.convert_tile_entry(add_tile_entry)
+
+        return tile_entry
+
+class TilesheetData(object):
+    def __init__(self, subdir_index, refs):
+        ts_all = refs.tileset_info[subdir_index]
+        self.ts_specs = {}
+        for ts_name, ts_spec in ts_all.items():
+            self.ts_specs = ts_spec
+            self.ts_name = ts_name
+            break
+        self.ts_path = refs.tileset_pathname + "/" + self.ts_name
+        print("parsing tilesheet {}".format(self.ts_name))
+        self.tile_entries = []
+        self.row_num = 0
+        self.width = self.ts_specs.get("sprite_width", refs.tileset_width)
+        self.height = self.ts_specs.get("sprite_height", refs.tileset_height)
+        self.offset_x = 0
+        self.offset_y = 0
+        subdir_name = self.ts_name.split(".png")[0] + "_{}x{}".format(self.width, self.height)
+        self.subdir_path = refs.tileset_pathname + "/pngs_" + subdir_name
+        if not self.standard(refs):
+            self.offset_x = self.ts_specs.get("sprite_offset_x", 0)
+            self.offset_y = self.ts_specs.get("sprite_offset_y", 0)
+        self.null_image = Vips.Image.grey(self.width, self.height)
+        self.row_pngs = ["null_image"]
+        self.fallback = False;
+        if self.ts_specs.get("fallback"):
+            self.fallback = True
+            return
+        refs.pngnum += 1
+        self.first_index = refs.pngnum
+        self.max_index = refs.pngnum
+
+    def standard(self, refs):
+        if self.offset_x or self.offset_y:
+            return False
+        return self.width == refs.tileset_width and self.height == refs.tileset_height
+
+    def merge_row(self, refs):
+        spacer = 16 - len(self.row_pngs)
+        refs.pngnum += spacer
+
+        in_list = []
+        
+        for png_pathname in self.row_pngs:
+            if png_pathname == "null_image":
+                in_list.append(self.null_image)
+            else:
+                vips_image = Vips.Image.pngload(png_pathname)
+                if not vips_image.hasalpha():
+￼                    vips_image = vips_image.addalpha()
+                if vips_image.width != self.width or vips_image.height != self.height:
+                     size_msg = "{} is {}x{}, sheet sprites are {}x{}."
+                     print(size_msg.format(png_pngname, vips_image.width, vips_image.height,
+                                           self.width, self.height))
+                     print("sprites in the {} tilesheet may be resized.".format(self.ts_name))
+                     print("All sprites in a tileshett directory should have the same dimensions.")
+                in_list.append(vips_image)
+        for i in range(0, spacer):
+            in_list.append(self.null_image)
+
+        return in_list
+
+    def walk_dirs(self, refs):
+        tmp_merged_pngs = []
+        for subdir_fpath, dirnames, filenames in os.walk(self.subdir_path):
+            #print("{} has dirs {} and files {}".format(subdir_fpath, dirnames, filenames))
+            for filename in filenames:
+                filepath = subdir_fpath + "/" + filename
+                if filename.endswith(".png"):
+                    pngname = filename.split(".png")[0]
+                    if pngname in refs.pngname_to_pngnum or pngname == "no_entry":
+                        print("skipping {}".format(pngname))
+                        continue
+                    self.row_pngs.append(filepath)
+                    refs.pngname_to_pngnum[pngname] = refs.pngnum
+                    refs.pngnum_to_pngname[refs.pngnum] = pngname
+                    refs.pngnum += 1
+                    if len(self.row_pngs) > 15:
+                        merged = self.merge_row(refs)
+                        self.row_num += 1
+                        self.row_pngs = []
+                        tmp_merged_pngs += merged
+                elif filename.endswith(".json"):
+                    with open(filepath, "r") as fp:
+                        tile_entry = json.load(fp)
+                        self.tile_entries.append(tile_entry)
+        if self.row_pngs:
+            merged = self.merge_row(refs)
+            tmp_merged_pngs += merged
+        return tmp_merged_pngs
+
+    def finalize_merges(self, merge_pngs):
+        out_image = Vips.Image.arrayjoin(merge_pngs, across=16)
+        out_image.pngsave(self.ts_path)
+
+args = argparse.ArgumentParser(description="Merge all the individal tile_entries and pngs in a tileset's directory into a tile_config.json and 1 or more tilesheet pngs.")
+args.add_argument("tileset_dir", action="store",
+                  help="local name of the tileset directory under gfx/")
+argsDict = vars(args.parse_args())
+
+tileset_dirname = argsDict.get("tileset_dir", "")
+
+refs = PngRefs(tileset_dirname)
+
+all_ts_data = []
+fallback_name = "fallback.png"
+
+for subdir_index in range(1, len(refs.tileset_info)):
+    ts_data = TilesheetData(subdir_index, refs)
+    if not ts_data.fallback:
+        tmp_merged_pngs = ts_data.walk_dirs(refs)
+
+        ts_data.finalize_merges(tmp_merged_pngs)
+
+        ts_data.max_index = refs.pngnum
+    all_ts_data.append(ts_data)
+
+#print("pngname to pngnum {}".format(json.dumps(refs.pngname_to_pngnum, indent=2)))
+#print("pngnum to pngname {}".format(json.dumps(refs.pngnum_to_pngname, sort_keys=True, indent=2)))
+
+tiles_new = []
+    
+for ts_data in all_ts_data:
+    if ts_data.fallback:
+        fallback_name = ts_data.ts_name
+        continue
+    ts_tile_entries = []
+    for tile_entry in ts_data.tile_entries:
+        converted_tile_entry = refs.convert_tile_entry(tile_entry)
+        ts_tile_entries.append(converted_tile_entry)
+    ts_conf = {
+        "file": ts_data.ts_name,
+        "tiles": ts_tile_entries,
+        "//": "range {} to {}".format(ts_data.first_index, ts_data.max_index)
+    }
+    if not ts_data.standard(refs):
+        ts_conf["sprite_width"] = ts_data.width
+        ts_conf["sprite_height"] = ts_data.height
+        ts_conf["sprite_offset_x"] = ts_data.offset_x
+        ts_conf["sprite_offset_y"] = ts_data.offset_y
+
+    #print("\tfinalizing tilesheet {}".format(ts_name))
+    tiles_new.append(ts_conf)
+
+FALLBACK["file"] = fallback_name
+tiles_new.append(FALLBACK)
+conf_data = {
+    "tile_info": [{
+        "width": refs.tileset_width,
+        "height": refs.tileset_height
+    }],
+    "tiles-new": tiles_new
+}
+tileset_confpath = refs.tileset_pathname + "/" + "tile_config.json"
+write_to_json(tileset_confpath, conf_data)

--- a/tools/gfx_tools/decompose.py
+++ b/tools/gfx_tools/decompose.py
@@ -1,0 +1,464 @@
+#!/bin/python
+
+# decompose.py
+# Split a gfx tile_config.json into 1000s of little directories, each with their own config
+# file and tile image.
+
+import argparse
+import copy
+import json
+import math
+import os
+import subprocess
+
+try:
+    import pyvips
+    Vips = pyvips
+except ImportError:
+    import gi
+    gi.require_version('Vips', '8.0')
+    from gi.repository import Vips
+
+# stupid stinking Python 2 versus Python 3 syntax
+def write_to_json(pathname, data, prettify=False):
+    with open(pathname, "w") as fp:
+        try:
+            json.dump(data, fp)
+        except ValueError:
+            fp.write(json.dumps(data))
+    cmd = ["./tools/format/json_formatter.cgi", pathname]
+    if prettify:
+        subprocess.call(cmd)
+
+
+def find_or_make_dir(pathname):
+    try:
+        os.stat(pathname)
+    except OSError:
+        os.mkdir(pathname)
+
+
+class TileSheetData(object):
+    def __init__(self, tilesheet_data, refs):
+        self.ts_filename = tilesheet_data.get("file", "")
+        #print("working on {}".format(self.ts_filename))
+        self.tile_id_to_tile_entrys = {}
+        self.sprite_height = tilesheet_data.get("sprite_height", refs.default_height)
+        self.sprite_width = tilesheet_data.get("sprite_width", refs.default_width)
+        self.sprite_offset_x = tilesheet_data.get("sprite_offset_x", 0)
+        self.sprite_offset_y = tilesheet_data.get("sprite_offset_y", 0)
+        self.write_dim = self.sprite_width != refs.default_width
+        self.write_dim |= self.sprite_height != refs.default_height
+        self.write_dim |= self.sprite_offset_x or self.sprite_offset_y
+        self.ts_pathname = refs.tileset_pathname + "/" + self.ts_filename
+        self.ts_image = Vips.Image.pngload(self.ts_pathname)
+        self.ts_width = self.ts_image.width
+        self.ts_tiles_per_row = math.floor(self.ts_width / self.sprite_width)
+        self.ts_height = self.ts_image.height
+        self.ts_rows = math.floor(self.ts_height / self.sprite_height)
+        self.pngnum_min = refs.last_pngnum
+        self.pngnum_max = refs.last_pngnum + self.ts_tiles_per_row * self.ts_rows - 1
+        #print("\t{}x{}; {} rows; spans {} to {}".format(self.ts_width, self.ts_height,
+        #                                                self.ts_rows, self.pngnum_min,
+        #                                                self.pngnum_max))
+        self.expansions = []
+        self.fallback = tilesheet_data.get("ascii")
+        refs.last_pngnum = self.pngnum_max + 1
+        refs.tspathname_to_tsfilename.setdefault(self.ts_pathname, self.ts_filename)
+
+    def check_for_expansion(self, tile_entry):
+        if tile_entry.get("fg", -10) == 0:
+            self.expansions.append(tile_entry)
+            return True
+        return False
+
+    def check_id_valid(self, tile_id):
+        if not tile_id:
+            return True
+        # wielded terrain isn't valid
+        if tile_id.startswith("overlay_wielded_t_"):
+            return False
+        if tile_id.startswith("overlay_wielded_mon_"):
+            return False
+        if tile_id.startswith("overlay_wielded_fd_"):
+            return False
+        if tile_id.startswith("overlay_wielded_f_"):
+            return False
+        # wielding or wearing overlays makes no sense
+        if tile_id.startswith("overlay_wielded_overlay"):
+            return False
+        if tile_id.startswith("overlay_worn_overlay"):
+            return False
+        return True
+
+    def parse_id(self, tile_entry):
+        all_tile_ids = []
+        read_tile_ids = tile_entry.get("id")
+        valid = True
+        if isinstance(read_tile_ids, list):
+            for tile_id in read_tile_ids:
+                valid &= self.check_id_valid(tile_id)
+                if tile_id and valid and tile_id not in all_tile_ids:
+                    all_tile_ids.append(tile_id)
+        else:
+            valid &= self.check_id_valid(read_tile_ids)
+            if read_tile_ids and valid and read_tile_ids not in all_tile_ids:
+                all_tile_ids.append(read_tile_ids)
+        if not valid:
+            return None, None
+        if not all_tile_ids:
+            return "background", ["background"]
+        #print("tile {}".format(all_tile_ids[0]))
+        return all_tile_ids[0], all_tile_ids
+
+    def parse_index(self, read_pngnums, all_pngnums, refs):
+        local_pngnums = []
+        if isinstance(read_pngnums, list):
+            for pngnum in read_pngnums:
+                if isinstance(pngnum, dict):
+                    sprite_ids = pngnum.get("sprite", -10)
+                    if isinstance(sprite_ids, list):
+                        for sprite_id in sprite_ids:
+                            if sprite_id < 0 or sprite_id in refs.delete_pngnums:
+                                continue
+                            if sprite_id not in all_pngnums:
+                                all_pngnums.append(sprite_id)
+                            if sprite_id not in local_pngnums:
+                                local_pngnums.append(sprite_id)
+                    else:
+                        if sprite_ids < 0 or sprite_ids in refs.delete_pngnums:
+                            continue
+                        if sprite_ids not in all_pngnums:
+                            all_pngnums.append(sprite_ids)
+                        if sprite_ids not in local_pngnums:
+                            local_pngnums.append(sprite_ids)
+                else:
+                    if pngnum < 0 or pngnum in refs.delete_pngnums:
+                        continue
+                    if pngnum not in all_pngnums:
+                        all_pngnums.append(pngnum)
+                    if pngnum not in local_pngnums:
+                        local_pngnums.append(pngnum)
+        elif read_pngnums >= 0 and read_pngnums not in refs.delete_pngnums:
+            if read_pngnums not in all_pngnums:
+                all_pngnums.append(read_pngnums)
+            if read_pngnums not in local_pngnums:
+                local_pngnums.append(read_pngnums)
+        return all_pngnums
+
+    def parse_png(self, tile_entry, refs):
+        all_pngnums = []
+        fg_id = tile_entry.get("fg", -10)
+        all_pngnums = self.parse_index(fg_id, all_pngnums, refs)
+
+        bg_id = tile_entry.get("bg", -10)
+        all_pngnums = self.parse_index(bg_id, all_pngnums, refs)
+
+        add_tile_entrys = tile_entry.get("additional_tiles", [])
+        for add_tile_entry in add_tile_entrys:
+            add_pngnums = self.parse_png(add_tile_entry, refs)
+            for add_pngnum in add_pngnums:
+                if add_pngnum not in all_pngnums:
+                    all_pngnums.append(add_pngnum)
+        # print("\tpngs: {}".format(all_pngnums))
+        return all_pngnums
+
+    def parse_tile_entry(self, tile_entry, refs):
+        if self.check_for_expansion(tile_entry):
+            return None
+        tile_id, all_tile_ids = self.parse_id(tile_entry)
+        if not tile_id:
+            # print("no id for {}".format(tile_entry))
+            return None
+        tile_id = tile_id.replace("/", "_")
+        all_pngnums = self.parse_png(tile_entry, refs)
+        offset = 0
+        for i in range(0, len(all_pngnums)):
+            pngnum = all_pngnums[i]
+            if pngnum in refs.pngnum_to_pngname:
+                continue
+            pngname = "{}_{}_{}".format(pngnum, tile_id, i + offset)
+            while pngname in refs.pngname_to_pngnum:
+                offset += 1
+                pngname = "{}_{}_{}".format(pngnum, tile_id, i + offset)
+            try:
+                refs.pngnum_to_pngname.setdefault(pngnum, pngname)
+                refs.pngname_to_pngnum.setdefault(pngname, pngnum)
+                refs.add_pngnum_to_tsfilepath(pngnum)
+            except TypeError:
+                print("failed to parse {}".format(json.dumps(tile_entry, indent=2)))
+                raise
+        return tile_id
+
+    def summarize(self, tile_info, refs):
+        #debug statement to verify pngnum_min and pngnum_max
+        #print("{} from {} to {}".format(self.ts_filename, self.pngnum_min, self.pngnum_max))
+        if self.fallback:
+            refs.ts_data[self.ts_filename] = self
+            ts_tile_info = {
+                "fallback": True
+            }
+            tile_info.append({self.ts_filename: ts_tile_info})
+            return
+        if self.pngnum_max > 0:
+            refs.ts_data[self.ts_filename] = self
+            ts_tile_info = {
+                "//": "indices {} to {}".format(self.pngnum_min, self.pngnum_max)
+            }
+            if self.write_dim:
+                ts_tile_info["sprite_offset_x"] = self.sprite_offset_x
+                ts_tile_info["sprite_offset_y"] = self.sprite_offset_y
+                ts_tile_info["sprite_width"] = self.sprite_width
+                ts_tile_info["sprite_height"] = self.sprite_height
+            #print("{}: {}".format(self.ts_filename, json.dumps(ts_tile_info, indent=2)))
+            tile_info.append({self.ts_filename: ts_tile_info})
+
+class ExtractionData(object):
+    def __init__(self, ts_filename, refs):
+        self.ts_data = refs.ts_data.get(ts_filename)
+        self.valid = False
+        if not self.ts_data.sprite_width or not self.ts_data.sprite_height:
+            return
+
+        self.valid = True
+
+        ts_base = ts_filename.split(".png")[0]
+        geometry_dim = "{}x{}".format(self.ts_data.sprite_width, self.ts_data.sprite_height)
+        pngs_dir = "/pngs_" +  ts_base + "_{}".format(geometry_dim)
+        self.ts_dir_pathname = refs.tileset_pathname + pngs_dir
+        find_or_make_dir(self.ts_dir_pathname)
+        self.tilenum_in_dir = 256
+        self.dir_count = 0
+        self.subdir_pathname = ""
+
+    def write_expansions(self):
+        for expand_entry in self.ts_data.expansions:
+            expansion_id = expand_entry.get("id", "expansion")
+            if not isinstance(expansion_id, str):
+                continue
+            expand_entry_pathname = self.ts_dir_pathname + "/" + expansion_id + ".json"
+            write_to_json(expand_entry_pathname, expand_entry)
+
+    def increment_dir(self):
+        if self.tilenum_in_dir > 255:
+            self.subdir_pathname = self.ts_dir_pathname + "/" + "images{}".format(self.dir_count)
+            find_or_make_dir(self.subdir_pathname)
+            self.tilenum_in_dir = 0
+            self.dir_count += 1
+        else:
+            self.tilenum_in_dir += 1
+        return self.subdir_pathname
+
+    def extract_image(self, png_index, refs):
+        if not png_index or refs.extracted_pngnums.get(png_index):
+            return
+        if png_index not in refs.pngnum_to_pngname:
+            return
+        pngname = refs.pngnum_to_pngname[png_index]
+        ts_pathname = refs.pngnum_to_tspathname[png_index]
+        ts_filename = refs.tspathname_to_tsfilename[ts_pathname]
+        self.increment_dir()
+        tile_data = refs.ts_data[ts_filename]
+        file_index = png_index - tile_data.pngnum_min
+        y_index = math.floor( file_index / tile_data.ts_tiles_per_row )
+        x_index = file_index - y_index * tile_data.ts_tiles_per_row
+        tile_off_x = max(0, tile_data.sprite_width * x_index)
+        tile_off_y = max(0, tile_data.sprite_height * y_index)
+        tile_image = tile_data.ts_image.extract_area(tile_off_x, tile_off_y,
+                                                     tile_data.sprite_width,
+                                                     tile_data.sprite_height)
+        tile_png_pathname = self.subdir_pathname + "/" + pngname + ".png"
+        tile_image.pngsave(tile_png_pathname)
+        refs.extracted_pngnums[png_index] = True
+
+    def write_images(self, refs):
+        for pngnum in range(self.ts_data.pngnum_min, self.ts_data.pngnum_max + 1):
+            out_data.extract_image(pngnum, refs)
+
+
+class PngRefs(object):
+    def __init__(self):
+        # dict of png absolute numbers to png names
+        self.pngnum_to_pngname = {}
+        # dict of pngnames to png numbers; used to control uniqueness
+        self.pngname_to_pngnum = {}
+        # dict of png absolute numbers to tilesheet paths, used to know where to extract images
+        self.pngnum_to_tspathname = {}
+        self.tspathname_to_tsfilename = {}
+        # list of pngs written out
+        self.extracted_pngnums = {}
+        # list of pngs to not use
+        self.delete_pngnums = []
+        # misc data
+        self.tileset_pathname = ""
+        self.default_width = 16
+        self.default_height = 16
+        self.last_pngnum = 0
+        self.ts_data = {}
+
+    def get_all_data(self, tileset_dirname, delete_pathname):
+        self.tileset_pathname = tileset_dirname
+        if not tileset_dirname.startswith("gfx/"):
+            self.tileset_pathname = "gfx/" + tileset_dirname
+
+        try:
+            os.stat(self.tileset_pathname)
+        except KeyError:
+            print("cannot find a directory {}".format(self.tileset_pathname))
+            exit -1
+
+        tileset_confname = refs.tileset_pathname + "/" + "tile_config.json"
+
+        try:
+            os.stat(tileset_confname)
+        except KeyError:
+            print("cannot find a directory {}".format(tileset_confname))
+            exit -1
+
+        if delete_pathname:
+            with open(delete_pathname) as del_file:
+                del_ranges = json.load(del_file)
+                for delete_range in del_ranges:
+                    if not isinstance(delete_range, list):
+                        contineu
+                    min_png = delete_range[0]
+                    max_png = min_png
+                    if len(delete_range) > 1:
+                        max_png = delete_range[1]
+                    for i in range(min_png, max_png + 1):
+                        self.delete_pngnums.append(i)
+
+        with open(tileset_confname) as conf_file:
+            return(json.load(conf_file))       
+
+    def add_pngnum_to_tsfilepath(self, pngnum):
+        if not isinstance(pngnum, int):
+            return
+        if pngnum in self.pngnum_to_tspathname:
+            return
+        for ts_filename, ts_data in self.ts_data.items():
+            if pngnum >= ts_data.pngnum_min and pngnum <= ts_data.pngnum_max:
+                self.pngnum_to_tspathname.setdefault(pngnum, ts_data.ts_pathname)
+                return
+        raise KeyError("index %s out of range", pngnum)
+
+    def convert_index(self, read_pngnums, new_index, new_id):
+        if isinstance(read_pngnums, list):
+            for pngnum in read_pngnums:
+                if isinstance(pngnum, dict):
+                    sprite_ids = pngnum.get("sprite", -10)
+                    if isinstance(sprite_ids, list):
+                        new_sprites = []
+                        for sprite_id in sprite_ids:
+                            if sprite_id >= 0 and sprite_id not in self.delete_pngnums:
+                                if not new_id:
+                                    new_id = self.pngnum_to_pngname[sprite_id]
+                                new_sprites.append(self.pngnum_to_pngname[sprite_id])
+                        pngnum["sprite"] = new_sprites
+                    else:
+                        if sprite_ids >= 0 and sprite_ids not in self.delete_pngnums:
+                            if not new_id:
+                                new_id = self.pngnum_to_pngname[sprite_ids]
+                            pngnum["sprite"] = self.pngnum_to_pngname[sprite_ids]
+                    new_index.append(pngnum)
+                elif pngnum >= 0 and pngnum not in self.delete_pngnums:
+                    if not new_id:
+                        new_id = self.pngnum_to_pngname[pngnum]
+                    new_index.append(self.pngnum_to_pngname[pngnum])
+        elif read_pngnums >= 0 and read_pngnums not in self.delete_pngnums:
+            if not new_id:
+                new_id = self.pngnum_to_pngname[read_pngnums]
+            new_index.append(self.pngnum_to_pngname[read_pngnums])
+        return new_id
+
+    def convert_pngnum_to_pngname(self, tile_entry):
+        new_fg = []
+        new_id = ""
+        fg_id = tile_entry.get("fg", -10)
+        new_id = self.convert_index(fg_id, new_fg, new_id)
+        bg_id = tile_entry.get("bg", -10)
+        new_bg = []
+        new_id = self.convert_index(bg_id, new_bg, new_id)
+        add_tile_entrys = tile_entry.get("additional_tiles", [])
+        for add_tile_entry in add_tile_entrys:
+            self.convert_pngnum_to_pngname(add_tile_entry)
+        tile_entry["fg"] = new_fg
+        tile_entry["bg"] = new_bg
+
+        return new_id, tile_entry
+
+    def report_missing(self):
+        for pngnum in self.pngnum_to_pngname:
+            if not self.extracted_pngnums.get(pngnum):
+                print("missing index {}, {}".format(pngnum, self.pngnum_to_pngname[pngnum]))
+
+
+args = argparse.ArgumentParser(description="Split a tileset's tile_config.json into a directory per tile containing the tile data and png.")
+args.add_argument("tileset_dir", action="store",
+                  help="local name of the tileset directory under gfx/")
+args.add_argument("--delete_file", dest="del_path", action="store",
+                  help="local name of file containing lists of ranges of indices to delete")
+argsDict = vars(args.parse_args())
+
+tileset_dirname = argsDict.get("tileset_dir", "")
+delete_pathname = argsDict.get("del_path", "")
+
+refs = PngRefs()
+all_tiles = refs.get_all_data(tileset_dirname, delete_pathname)
+
+all_tilesheet_data = all_tiles.get("tiles-new", [])
+tile_info = all_tiles.get("tile_info", {})
+if tile_info:
+    refs.default_width = tile_info[0].get("width")
+    refs.default_height = tile_info[0].get("height")
+
+overlay_ordering = all_tiles.get("overlay_ordering", [])
+ts_sequence = []
+for tilesheet_data in all_tilesheet_data:
+    ts_data = TileSheetData(tilesheet_data, refs)
+    ts_data.summarize(tile_info, refs)
+    ts_sequence.append(ts_data.ts_filename)
+
+for tilesheet_data in all_tilesheet_data:
+    ts_filename = tilesheet_data.get("file", "")
+    ts_data = refs.ts_data[ts_filename]
+    if ts_data.fallback:
+        continue
+    tile_id_to_tile_entrys = {}
+    all_tile_entry = tilesheet_data.get("tiles", [])
+    for tile_entry in all_tile_entry:
+        tile_id = ts_data.parse_tile_entry(tile_entry, refs)
+        if tile_id:
+            tile_id_to_tile_entrys.setdefault(tile_id, [])
+            tile_id_to_tile_entrys[tile_id].append(tile_entry)
+    ts_data.tile_id_to_tile_entrys = tile_id_to_tile_entrys
+
+#debug statements to verify pngnum_to_pngname and pngname_to_pngnum
+#print("pngnum_to_pngname: {}".format(json.dumps(refs.pngnum_to_pngname, sort_keys=True, indent=2)))
+#print("pngname_to_pngnum: {}".format(json.dumps(refs.pngname_to_pngnum, sort_keys=True, indent=2)))
+#print("{}".format(json.dumps(file_tile_id_to_tile_entrys, indent=2)))
+#print("{}".format(json.dumps(refs.pngnum_to_tspathname, indent=2)))
+
+for ts_filename in ts_sequence:
+    out_data = ExtractionData(ts_filename, refs)
+
+    if not out_data.valid:
+        continue
+    out_data.write_expansions()
+
+    for tile_id, tile_entrys in out_data.ts_data.tile_id_to_tile_entrys.items():
+        #print("tile id {} with {} entries".format(tile_id, len(tile_entrys)))
+        for tile_entry in tile_entrys:
+            subdir_pathname = out_data.increment_dir()
+            tile_entry_name, tile_entry = refs.convert_pngnum_to_pngname(tile_entry)
+            if not tile_entry_name:
+                continue
+            tile_entry_pathname = subdir_pathname + "/" + tile_entry_name + ".json"
+            write_to_json(tile_entry_pathname, tile_entry)
+    out_data.write_images(refs)
+
+if tile_info:
+    tile_info_pathname = refs.tileset_pathname + "/" + "tile_info.json"
+    write_to_json(tile_info_pathname, tile_info, True)
+
+refs.report_missing()


### PR DESCRIPTION
#### Summary
```SUMMARY: Infrastructure "tilesets: add tools to automatically create tilesheets"```

#### Purpose of change
Creating and especially maintaining tilesets, because all the tilesheets share a common, sequential index.  Adding a new tile to the middle of a tilesheet requires updating all the indexes for every tile that follows.

Simplify the process through automation scripts.

#### Describe the solution
Add two new scripts: one decomposes an existing tilesheet into individual tile files with arbitrary names and corresponding tile_entry files, and the second composes the tile files and tile_entry files into tilesheets with dynamically generated indices.

#### Additional context
Sample automatically generated tiles from ChestHole16:
![tree_32x40](https://user-images.githubusercontent.com/8007405/65809110-72762980-e15f-11e9-883d-3aa961a002fc.png)
